### PR TITLE
[Vulns] Session ID prediction, Spring4shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Vulnerability: SQLI Auth Bypass
 - Vulnerability: Forced Browsing Auth Bypass
 - Vulnerability: Parameter Modification Auth Bypass
+- Vulnerability: Spring4shell (CVE-2022-22965)
 - FP: Information via "X-Powered-By" HTTP Response Header Field(s) Leaked By Server
 - FP: Dangerous JS Functions
 - GIF Favicon

--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ docker-compose up
 - SQLI Auth Bypass
 - Forced Browsing Auth Bypass
 - Parameter Modification Auth Bypass
+- Spring4shell (CVE-2022-22965)

--- a/public/index.php
+++ b/public/index.php
@@ -62,6 +62,7 @@ require __DIR__ . '/../src/app/vulnerabilities/SQLI Auth Bypass.php';
 require __DIR__ . '/../src/app/vulnerabilities/Forced Browsing Auth Bypass.php';
 require __DIR__ . '/../src/app/vulnerabilities/Parameter Modification Auth Bypass.php';
 require __DIR__ . '/../src/app/vulnerabilities/Session ID Modification Auth Bypass.php';
+require __DIR__ . '/../src/app/vulnerabilities/Spring4shell.php';
 require __DIR__ . '/../src/app/vulnerabilities/FP/X-Powered-By Header.php';
 require __DIR__ . '/../src/app/vulnerabilities/FP/Dangerous JS Functions.php';
 

--- a/public/index.php
+++ b/public/index.php
@@ -61,6 +61,7 @@ require __DIR__ . '/../src/app/vulnerabilities/Server Side Template Injection.ph
 require __DIR__ . '/../src/app/vulnerabilities/SQLI Auth Bypass.php';
 require __DIR__ . '/../src/app/vulnerabilities/Forced Browsing Auth Bypass.php';
 require __DIR__ . '/../src/app/vulnerabilities/Parameter Modification Auth Bypass.php';
+require __DIR__ . '/../src/app/vulnerabilities/Session ID Modification Auth Bypass.php';
 require __DIR__ . '/../src/app/vulnerabilities/FP/X-Powered-By Header.php';
 require __DIR__ . '/../src/app/vulnerabilities/FP/Dangerous JS Functions.php';
 

--- a/src/app/index.php
+++ b/src/app/index.php
@@ -12,6 +12,14 @@ $app->get(
         $expected_key = "attachment_id";
         $expected_value = "100";
         $query_params = $request->getQueryParams();
+
+        $cookie_name = "AUTH";
+        $cookie_value = new stdClass();
+        $cookie_value->user = "user1";
+        $cookie_value->role = "stdUser";
+        $cookieJSON = json_encode($cookie_value);
+        $cookieB64 = base64_encode($cookieJSON);
+        setcookie($cookie_name, $cookieB64, time() + (86400 * 30), "/");
         
         foreach ($query_params as $key => $value) {
             
@@ -52,7 +60,7 @@ $app->get(
 <div class="container">
   <h3>Welcome to HypeJab! 💉 😃 </h3>
   <p>HypeJab is a deliberately vulnerable web application intended for benchmarking automated scanners.</p>
-  <p>v1.0.5</p>
+  <p>v1.0.6</p>
 </div>
 
 </body>

--- a/src/app/vulnerabilities/Session ID Modification Auth Bypass.php
+++ b/src/app/vulnerabilities/Session ID Modification Auth Bypass.php
@@ -1,0 +1,74 @@
+<?php
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Factory\AppFactory;
+
+$app->get(
+    '/session-id-modification-auth-bypass',
+    function (Request $request, Response $response, $args) {
+        require __DIR__ . '/../login/checkSession.php';
+
+        $cookieB64Decode = base64_decode($_COOKIE["AUTH"]);
+        $cookieJsonDecode = json_decode($cookieB64Decode);
+        $authCookieUser = $cookieJsonDecode->user;
+        $authCookieRole = $cookieJsonDecode->role;
+
+        if ($authCookieRole == "admin") {
+            $isAdmin = TRUE;
+        } else {
+            $isAdmin = FALSE;
+        }
+
+        if($isAdmin) {
+            $response->getBody()->write('
+            <html>
+                <head>
+                    <title>SESSION ID MODIFICATION AUTH BYPASS</title>
+                    <style>
+                        h1{font-family: sans-serif;}
+                    </style>
+                </head>
+                <body>
+                    <h1>WE USE SECURE SESSION IDs</h1>
+                    <h4> Welcome ' . $authCookieUser . '</h4>
+                    <p> Role - ' . $authCookieRole . '</p>
+                    <h2> Manage users </h2>
+                    <table>
+                        <tr>
+                            <th> Peter </th>
+                            <td> <button>Delete</button> </td>
+                            <td> <button>Promote to admin</button> </td>
+                        </tr>
+                        <tr>
+                            <th> Carlos </th>
+                            <td> <button>Delete</button> </td>
+                            <td> <button>Promote to admin</button> </td>
+                        </tr>
+                    </table>
+                </body>
+            </html>
+                ');
+        } else {
+            $response->getBody()->write('
+            <html>
+                <head>
+                    <title>SESSION ID MODIFICATION AUTH BYPASS</title>
+                    <style>
+                        h1{font-family: sans-serif;}
+                    </style>
+                </head>
+                <body>
+                    <h1>WE USE SECURE SESSION IDs</h1>
+                    <h4> Welcome ' . $authCookieUser . '</h4>
+                    <p> Role - ' . $authCookieRole . '</p>
+                </body>
+            </html>
+                ');
+        }
+        
+        return $response->withHeader("content-type", "text/html")
+                    ->withStatus(200);
+        
+    }
+);

--- a/src/app/vulnerabilities/Spring4shell.php
+++ b/src/app/vulnerabilities/Spring4shell.php
@@ -1,0 +1,25 @@
+<?php
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Factory\AppFactory;
+
+$app->get(
+    '/astra4shell.jsp',
+    function (Request $request, Response $response, $args) {
+        require __DIR__ . '/../login/checkSession.php';
+        $query = $request->getQueryParams()['cmd'];
+        if ($query == 'cat /etc/passwd') {
+            $returnText = 'root:x:0:0:root:/root:/bin/bash daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin bin:x:2:2:bin:/bin:/usr/sbin/nologin sys:x:3:3:sys:/dev:/usr/sbin/nologin sync:x:4:65534:sync:/bin:/bin/sync games:x:5:60:games:/usr/games:/usr/sbin/nologin man:x:6:12:man:/var/cache/man:/usr/sbin/nologin lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin mail:x:8:8:mail:/var/mail:/usr/sbin/nologin news:x:9:9:news:/var/spool/news:/usr/sbin/nologin uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin proxy:x:13:13:proxy:/bin:/usr/sbin/nologin www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin backup:x:34:34:backup:/var/backups:/usr/sbin/nologin list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin _apt:x:100:65534::/nonexistent:/usr/sbin/nologin messagebus:x:101:102::/nonexistent:/usr/sbin/nologin //';
+        } else if ($query == 'whoami') {
+            $returnText = 'root //';
+        } else if ($query == 'id') {
+            $returnText = 'uid=0(root) gid=0(root) groups=0(root) //';
+        } else {
+            $returnText = $query . ' command not found';
+        }
+        $response->getBody()->write($returnText);
+        return $response->withHeader("content-type", "text/html")
+                        ->withStatus(200);
+    }
+);


### PR DESCRIPTION
In this example, session id can be predicted by decoding the base-64 encoded cookie and changing the role field to "admin" and then encoding it back to base-64.

Spring4shell scanner rule creates a jsp file with cmd parameter which can be used for RCE. So the route for the jsp file with cmd parameter has been added.

Signed-off-by: Karthik UJ <karthikuj2001@gmail.com>