### PR TITLE
Adds hypejab vuln for graphql api introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ docker-compose up
 - Debug Mode Enabled
 - CVE-2022-26134
 - Missing API Security Headers
+- GraphQL API Introspection

--- a/public/index.php
+++ b/public/index.php
@@ -88,6 +88,7 @@ require __DIR__ . '/../src/app/vulnerabilities/LaravelTelescope.php';
 require __DIR__ . '/../src/app/vulnerabilities/404 Check.php';
 require __DIR__ . '/../src/app/vulnerabilities/server-config.php';
 require __DIR__ . '/../src/app/vulnerabilities/text4shell.php';
+require __DIR__ . '/../src/app/vulnerabilities/GraphQL Introspection.php';
 
 // False positives section
 require __DIR__ . '/../src/app/vulnerabilities/FP/X-Powered-By Header.php';

--- a/src/app/vulnerabilities/GraphQL Introspection.php
+++ b/src/app/vulnerabilities/GraphQL Introspection.php
@@ -1,0 +1,61 @@
+<?php
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Factory\AppFactory;
+
+$app->get(
+    '/graphql',
+    function (Request $request, Response $response) {
+        $data = '{"errors":[{"message":"Unexpected end of document","locations":[]}]}';
+
+        $response->getBody()->write($data);
+        return $response->withHeader("content-type", "application/json")
+                        ->withStatus(200);;
+    }
+);
+
+$app->post('/graphql', function (Request $request, Response $response) {
+    $query = $request->getParsedBody()['query'];
+
+    // Check if introspection query is made
+    if (preg_match('/__schema/', $query)) {
+        // If introspection query is made, return introspection information
+        $introspection = '{
+            "__schema": {
+                "queryType": {
+                  "name": "Query"
+                },
+                "types": [
+                  {
+                    "kind": "OBJECT",
+                    "name": "Query",
+                    "fields": [
+                      {
+                        "name": "hello",
+                        "type": {
+                          "kind": "SCALAR",
+                          "name": "String"
+                        }
+                      }
+                    ]
+                  }
+                ]
+            }
+        }';
+
+        $response->getBody()->write($introspection);
+    } else {
+        // If not introspection query, return dummy data
+        $data = '{
+            "data": {
+                "hello": "world"
+            }
+        }';
+
+        $response->getBody()->write($data);
+    }
+
+    return $response->withHeader("content-type", "application/json")
+                    ->withStatus(200);;
+});


### PR DESCRIPTION
- GraphQL API Introspection allows the attacker to query out the schema of the API.
- This helps the attacker to gain a deeper understanding of the API and attack it in a better way.
- [Resource](https://www.apollographql.com/blog/graphql/security/why-you-should-disable-graphql-introspection-in-production/)

Signed-off-by: Karthik UJ <karthikuj2001@gmail.com>