### PR TITLE
Add Railway deployment support

### DIFF
--- a/Dockerfile.railway
+++ b/Dockerfile.railway
@@ -1,0 +1,19 @@
+FROM php:8.3-cli-bookworm
+
+COPY --from=composer:2.5.8 /usr/bin/composer /usr/local/bin/composer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip git \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+WORKDIR /app
+
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist
+
+COPY . .
+
+EXPOSE 8080
+CMD ["sh", "-c", "php -S 0.0.0.0:${PORT:-8080} -t public public/index.php"]

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,6 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile.railway"
+
+[deploy]
+restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
## Summary
- Add `Dockerfile.railway` (PHP 8.3 CLI + built-in server on `$PORT`) so the app can run as a single Railway service.
- Add `railway.toml` pointing Railway at that Dockerfile, leaving the existing k8s/`docker-compose` PHP-FPM `Dockerfile` unchanged.

## Test plan
- [ ] After merge, confirm Railway auto-deploy from `main` builds with `Dockerfile.railway`
- [ ] Hit the Railway URL and verify homepage returns 200
- [ ] Confirm local `docker-compose` / k8s still use the original `Dockerfile`